### PR TITLE
nginx-demo image update: 5ecdda7

### DIFF
--- a/infra/nginx-demo/kustomize/overlays/default/kustomization.yaml
+++ b/infra/nginx-demo/kustomize/overlays/default/kustomization.yaml
@@ -6,6 +6,6 @@ patches:
 - path: nginx-depl.yaml
 # rewrite and check this in to update images
 images:
-- digest: sha256:c67b65808de8ebbda8e09403b0904e635abd7decbd6d1576ba3b3e60d9ba9480
+- digest: sha256:87dbb46478a71468c2d502e912fc6bdf9c7cbd4237aa50d81868525b2ae7828b
   name: gnomesoft/nginx-demo
   newName: gnomesoft/nginx-demo


### PR DESCRIPTION
Updated digest for image gnomesoft/nginx-demo:5ecdda7